### PR TITLE
Fixed RWLock.release_read

### DIFF
--- a/toro/__init__.py
+++ b/toro/__init__.py
@@ -939,7 +939,7 @@ class RWLock(object):
 
         If not locked, raise a RuntimeError.
         """
-        if not self.locked():
+        if self._block.counter == self._max_readers:
             raise RuntimeError('release unlocked lock')
         self._block.release()
 


### PR DESCRIPTION
RWLock.release_read now can partially release lock acquired on read.