### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ toro
 :Info: Synchronization primitives for Tornado coroutines.
 :Author: A\. Jesse Jiryu Davis
 
-Documentation: http://toro.readthedocs.org/
+Documentation: https://toro.readthedocs.io/
 
 .. important:: Toro is completed and deprecated; its features have been merged
   into Tornado. Development of locks and queues for Tornado coroutines continues


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
